### PR TITLE
cuda-compat v13.1.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+
+staging_channel_upload_target: ctk-13.1.1-build-1
+
+channels:
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,0 @@
-c_stdlib_version:  # [linux]
-  - "2.28"         # [linux]
-
-c_compiler_version:    # [linux]
-  - 14.3.0             # [linux]
-cxx_compiler_version:  # [linux]
-  - 14.3.0             # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cuda-compat" %}
-{% set driver_version = "590.44.01" %}
-{% set cuda_version = "13.1.0" %}
+{% set driver_version = "590.48.01" %}
+{% set cuda_version = "13.1.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64]
@@ -12,8 +12,8 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/nvidia_driver/{{ platform }}/nvidia_driver-{{ platform }}-{{ driver_version }}-archive.{{ extension }}
-  sha256: 99938a9a6c911569d875682b8a326e53bf152ff192248b3f4ab03fd445577177  # [linux64]
-  sha256: 4e7d189e77102a79d3be49cb6f1116b68655eb10b14970660e9dab36f33fb59e  # [aarch64]
+  sha256: 7e66ff6c8318f3f981d442d7451c791fb1e9cf05f45648a3f081242d056dde4f  # [linux64]
+  sha256: 0e67b96b10720b6cb371482075aaf7fe669321e1e3c15ef3c149784d433036b0  # [aarch64]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cuda-compat" %}
-{% set driver_version = "580.95.05" %}
-{% set cuda_version = "13.0.2" %}
+{% set driver_version = "590.44.01" %}
+{% set cuda_version = "13.1.0" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64]
@@ -12,8 +12,8 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/nvidia_driver/{{ platform }}/nvidia_driver-{{ platform }}-{{ driver_version }}-archive.{{ extension }}
-  sha256: 3528df4fb0c7a1665ae2af5d26effeb67f76fc86742ffc1defd7714408405d4d  # [linux64]
-  sha256: 95b52919632928d7a245e5696b71cd68285e6bffd1f22cdcd4f9686d5d5b0b09  # [aarch64]
+  sha256: 99938a9a6c911569d875682b8a326e53bf152ff192248b3f4ab03fd445577177  # [linux64]
+  sha256: 4e7d189e77102a79d3be49cb6f1116b68655eb10b14970660e9dab36f33fb59e  # [aarch64]
 
 build:
   number: 0


### PR DESCRIPTION
cuda-compat 13.1.1

**Destination channel:** defaults

### Links

- [PKG-12002](https://anaconda.atlassian.net/browse/PKG-12002) 
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- CUDA 13.1 release


[PKG-12002]: https://anaconda.atlassian.net/browse/PKG-12002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ