### PR TITLE
cuda-compat v13.1.1 b1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,9 +1,0 @@
-build_parameters:
-  - "--suppress-variables"
-  #- "--skip-existing"
-  - "--error-overlinking"
-
-staging_channel_upload_target: ctk-13.1.1-build-1
-
-channels:
-  - https://staging.continuum.io/pbp/ctk-13.1.1-build-1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,7 @@ stages:
   jobs:
     - job: Skip
       pool:
-        vmImage: 'ubuntu-22.04'
+        vmImage: 'ubuntu-latest'
       variables:
         DECODE_PERCENTS: 'false'
         RET: 'true'

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,18 +1,14 @@
 #!/bin/bash
 
+set -ex
+
 # Install to conda style directories
 [[ -d lib64 ]] && mv lib64 lib
 mkdir -p ${PREFIX}/cuda-compat
 
 check-glibc lib/*.so.*
 
-cp -v lib/libcuda.so.${DRV_VERSION} ${PREFIX}/cuda-compat
-ln -sv libcuda.so.${DRV_VERSION} ${PREFIX}/cuda-compat/libcuda.so.1
-ln -sv libcuda.so.1 ${PREFIX}/cuda-compat/libcuda.so
-cp -v lib/libnvidia-nvvm.so.${DRV_VERSION} ${PREFIX}/cuda-compat
-ln -sv libnvidia-nvvm.so.${DRV_VERSION} ${PREFIX}/cuda-compat/libnvidia-nvvm.so.4
-ln -sv libnvidia-nvvm.so.4 ${PREFIX}/cuda-compat/libnvidia-nvvm.so
-cp -v lib/libnvidia-ptxjitcompiler.so.${DRV_VERSION} ${PREFIX}/cuda-compat
-ln -sv libnvidia-ptxjitcompiler.so.${DRV_VERSION} ${PREFIX}/cuda-compat/libnvidia-ptxjitcompiler.so.1
-cp -v lib/libcudadebugger.so.${DRV_VERSION} ${PREFIX}/cuda-compat
-ln -sv libcudadebugger.so.${DRV_VERSION} ${PREFIX}/cuda-compat/libcudadebugger.so.1
+cp -vd compat/libcuda.so* ${PREFIX}/cuda-compat/
+cp -vd compat/libnvidia-nvvm.so* ${PREFIX}/cuda-compat/
+cp -vd compat/libnvidia-ptxjitcompiler.so* ${PREFIX}/cuda-compat/
+cp -vd compat/libcudadebugger.so* ${PREFIX}/cuda-compat/

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,7 +6,7 @@ set -ex
 [[ -d lib64 ]] && mv lib64 lib
 mkdir -p ${PREFIX}/cuda-compat
 
-check-glibc lib/*.so.*
+check-glibc compat/*.so.*
 
 cp -vd compat/libcuda.so* ${PREFIX}/cuda-compat/
 cp -vd compat/libnvidia-nvvm.so* ${PREFIX}/cuda-compat/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,7 @@
 {% set name = "cuda-compat" %}
 {% set driver_version = "590.48.01" %}
 {% set cuda_version = "13.1.1" %}
+{% set cuda_major_minor = cuda_version.split('.')[:2] | join('.') %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64]
@@ -11,12 +12,12 @@ package:
   version: {{ cuda_version }}
 
 source:
-  url: https://developer.download.nvidia.com/compute/cuda/redist/nvidia_driver/{{ platform }}/nvidia_driver-{{ platform }}-{{ driver_version }}-archive.{{ extension }}
-  sha256: 7e66ff6c8318f3f981d442d7451c791fb1e9cf05f45648a3f081242d056dde4f  # [linux64]
-  sha256: 0e67b96b10720b6cb371482075aaf7fe669321e1e3c15ef3c149784d433036b0  # [aarch64]
+  url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_compat/{{ platform }}/cuda_compat-{{ platform }}-{{ driver_version }}_cuda{{ cuda_major_minor }}-archive.{{ extension }}
+  sha256: 0e8c1ec14c2abbce76943cb32907b39237a41bf267ec6665f04d48b240ae539f  # [linux64]
+  sha256: f3e02edc1a1080f44ec69478011e73218c7e20eaf52422963fd084ad0310bb64  # [aarch64]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [osx or win or ppc64le]
   script_env:
     - DRV_VERSION={{ driver_version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,9 @@ outputs:
 
   - name: cuda-compat-impl
     version: {{ driver_version }}
+    build:                                 # [linux and aarch64]
+      overlinking_ignore_patterns:         # [linux and aarch64]
+        - cuda-compat/libcudadebugger.so*  # [linux and aarch64]
     files:
       - cuda-compat
     requirements:


### PR DESCRIPTION
cuda-compat 13.1.1 b1

**Destination channel:** defaults

### Links

- [PKG-12811](https://anaconda.atlassian.net/browse/PKG-12811) 

### Explanation of changes:

- Sync with the upstream feedstock
- Switch to using a dedicated redist
- Using `overlinking_ignore_patterns` as a temporary fix for LIEF's `TAG not valid` error.
- No package is dependent on `cuda-compat` and it is also not dependent on anything critical / non-existent, so we don't need to use staging channels.



[PKG-12811]: https://anaconda.atlassian.net/browse/PKG-12811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ