### PR TITLE
cuda-compat v12.9.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,0 @@
-c_stdlib_version:  # [linux]
-  - "2.28"         # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,6 @@ requirements:
 
 outputs:
   - name: cuda-compat
-
     requirements:
       run:
         - {{ pin_subpackage("cuda-compat-impl", exact=True) }}
@@ -48,6 +47,9 @@ outputs:
 
   - name: cuda-compat-impl
     version: {{ driver_version }}
+    build:                                 # [linux and aarch64]
+      overlinking_ignore_patterns:         # [linux and aarch64]
+        - cuda-compat/libcudadebugger.so*  # [linux and aarch64]
     files:
       - cuda-compat
     requirements:


### PR DESCRIPTION
cuda-compat 12.9.1

**Destination channel:** defaults

### Links

- [PKG-12770](https://anaconda.atlassian.net/browse/PKG-12770) 

### Explanation of changes:

- Release for CUDA 12.9
- Using `overlinking_ignore_patterns` as a temporary fix for LIEF's `TAG not valid` error.


[PKG-12770]: https://anaconda.atlassian.net/browse/PKG-12770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ